### PR TITLE
chore(security): bumpear Pillow a 12.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==5.1.15
-Pillow==12.1.1
+Pillow==12.2.0
 django-ckeditor==6.7.0
 requests==2.33.0
 django-allauth==65.14.1


### PR DESCRIPTION
Cierra el aviso de Dependabot sobre Pillow vulnerable.

```
- Pillow==12.1.1
+ Pillow==12.2.0
```

Severity: high